### PR TITLE
Update environment_vars.yaml

### DIFF
--- a/dry-configurations/production/environment_vars.yaml
+++ b/dry-configurations/production/environment_vars.yaml
@@ -2,6 +2,6 @@ snet_address: ["10.0.0.0/24"]
 vnet_address: ["10.0.0.0/16"]
 servername: "calabserver"
 rgname: "REPLACEME"
-vm_size: "Basic_A1"
+vm_size: "Standard_B1s"
 admin_username: "terradmin"
 admin_password: "P@ssw0rdP@SSW0rd"


### PR DESCRIPTION
The VM size "Basic_A1" is deprecated and no longer available in most Azure regions. 
Updating to "Standard_B1s" (1 vCPU, 1 GB RAM)